### PR TITLE
Return & use error code from OpenVR initialisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # qrvr
-SteamVR QR code reader for node.js
+
+SteamVR QR code reader for node.js.
+
+Note: OpenVR is required for qrvr to work. See the error codes below for more details.
 
 ```
 npm install qrvr
@@ -7,9 +10,41 @@ npm install qrvr
 
 ```
 const qrvr = require('qrvr');
-qrvr.start().then(s => {
+const exitCode = qrvr.start().then(s => {
   console.log('started', s);
 });
+
+if (exitCode !== 0) {
+  // Handle exit code, as per https://github.com/ValveSoftware/openvr/wiki/HmdError
+}
 ```
 
 <img width="958" alt="card" src="https://user-images.githubusercontent.com/6926057/80404207-d516db80-888e-11ea-8373-7fd9d819fbed.PNG">
+
+## Development instructions
+
+The core qrvr code is in [`./openvr/test/main.cpp`](./openvr/test/main.cpp).
+
+Note you need **Python 2.7**, **VS 2017**, and **Node v13** to build the package successfullly. You can use something like [nvm-windows](https://github.com/coreybutler/nvm-windows) to manage multiple Node versions.
+
+Once you have all the dependencies, run:
+
+```
+nvm use 13 # e.g. if you use nvm to manage Node versions
+npm install --python=python2.7 --msvs_version=2017
+```
+
+in the root.
+
+This will produce the final binary `qr.node` inside the `./build/Release` directory.
+
+## Errors
+
+qrvr requires [OpenVR](https://github.com/ValveSoftware/openvr), which may fail initialisation. If it does, running `qrvr.start()` will return an non-0 exit code from https://github.com/ValveSoftware/openvr/wiki/HmdError. The most common ones are likely:
+
+- `HmdError_Unknown`: 1
+- `HmdError_Init_InstallationNotFound`: 100
+- `HmdError_Init_InstallationCorrupt`: 101
+- `HmdError_Init_VRClientDLLNotFound`: 102
+
+Please check the linked wiki for an exhaustive list and explanations.

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ npm install qrvr
 
 ```
 const qrvr = require('qrvr');
-const exitCode = qrvr.start().then(s => {
-  console.log('started', s);
-});
-
-if (exitCode !== 0) {
-  // Handle exit code, as per https://github.com/ValveSoftware/openvr/wiki/HmdError
-}
+qrvr.start().then(
+  s => console.log('started', s),
+  errorCode => {
+    // Handle error code, as per https://github.com/ValveSoftware/openvr/wiki/HmdError
+    console.log(errorCode);
+  }
+);
 ```
 
 <img width="958" alt="card" src="https://user-images.githubusercontent.com/6926057/80404207-d516db80-888e-11ea-8373-7fd9d819fbed.PNG">
@@ -40,7 +40,7 @@ This will produce the final binary `qr.node` inside the `./build/Release` direct
 
 ## Errors
 
-qrvr requires [OpenVR](https://github.com/ValveSoftware/openvr), which may fail initialisation. If it does, running `qrvr.start()` will return an non-0 exit code from https://github.com/ValveSoftware/openvr/wiki/HmdError. The most common ones are likely:
+qrvr requires [OpenVR](https://github.com/ValveSoftware/openvr), which may fail initialisation. If it does, running `qrvr.start()` will reject with a non-0 exit code from https://github.com/ValveSoftware/openvr/wiki/HmdError. The most common ones are likely:
 
 - `HmdError_Unknown`: 1
 - `HmdError_Init_InstallationNotFound`: 100

--- a/index.js
+++ b/index.js
@@ -6,25 +6,22 @@ const ws = require('ws');
 const engine = require('./build/Release/qr.node');
 
 async function initQr(qrEmitter, locomotionEmitter) {
-  return new Promise((resolve, reject) => {
-    const resultCode = engine.initVr();
+  const resultCode = engine.initVr();
 
-    // Reject if there was an error initializing OpenVR
-    // See https://github.com/ValveSoftware/openvr/wiki/HmdError for error codes
-    if (resultCode !== 0) {
-      console.error(resultCode === 100 ? 'OpenVR Installation not found' : 'Error initialising OpenVR', resultCode);
-      reject(resultCode);
-      return;
-    }
+  // Reject if there was an error initializing OpenVR
+  // See https://github.com/ValveSoftware/openvr/wiki/HmdError for error codes
+  if (resultCode !== 0) {
+    console.error(resultCode === 100 ? 'OpenVR Installation not found' : 'Error initialising OpenVR', resultCode);
+    throw resultCode;
+  }
 
-    engine.createQrEngine(qrCode => qrEmitter.emit('qrCode', qrCode));
+  engine.createQrEngine(qrCode => qrEmitter.emit('qrCode', qrCode));
 
-    engine.createLocomotionEngine(locomotionInput =>
-      locomotionEmitter.emit('locomotionInput', locomotionInput)
-    );
-    engine.startThread();
-    resolve();
-  });
+  engine.createLocomotionEngine(locomotionInput =>
+    locomotionEmitter.emit('locomotionInput', locomotionInput)
+  );
+  engine.startThread();
+  return 0;
 }
 
 async function start({

--- a/index.js
+++ b/index.js
@@ -18,7 +18,18 @@ async function start({
   });
   presenceWss.on('connection', (s, req) => {
     if (!initialized) {
-      engine.initVr();
+      const resultCode = engine.initVr();
+
+      // Don't continue if there was an error initializing OpenVR
+      // See https://github.com/ValveSoftware/openvr/wiki/HmdError for error codes
+      if (resultCode === 100) {
+        console.error('OpenVR Installation not found', resultCode);
+        return process.exit(resultCode);
+      } else if (resultCode !== 0) {
+        console.error('Error initialising OpenVR', resultCode);
+        return process.exit(resultCode);
+      }
+
       qrEmitter = new EventEmitter();
       engine.createQrEngine(qrCode => {
         qrEmitter.emit('qrCode', qrCode);

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const http = require('http');
 const events = require('events');
-const { EventEmitter } = events;
+const {EventEmitter} = events;
 const express = require('express');
 const ws = require('ws');
 const engine = require('./build/Release/qr.node');
@@ -43,7 +43,7 @@ async function start({
       let authed = typeof key !== 'string';
       s.on('message', s => {
         const j = JSON.parse(s);
-        const { method } = j;
+        const {method} = j;
         switch (method) {
           case 'init': {
             if (!authed) {
@@ -52,12 +52,12 @@ async function start({
             break;
           }
           case 'setSceneAppLocomotionEnabled': {
-            const { data } = j;
+            const {data} = j;
             engine.setSceneAppLocomotionEnabled(data);
             break;
           }
           case 'setChaperoneTransform': {
-            let { data } = j;
+            let {data} = j;
             if (data) {
               data = Float32Array.from(data);
             }
@@ -70,7 +70,6 @@ async function start({
           }
         }
       });
-
       const _onQrCode = qrCode => {
         if (authed) {
           s.send(JSON.stringify({
@@ -80,7 +79,6 @@ async function start({
         }
       };
       qrEmitter.on('qrCode', _onQrCode);
-
       const _onLocomotionInput = locomotionInput => {
         if (authed) {
           s.send(JSON.stringify({
@@ -90,7 +88,6 @@ async function start({
         }
       };
       locomotionEmitter.on('locomotionInput', _onLocomotionInput);
-
       s.once('close', () => {
         live = false;
 
@@ -106,17 +103,14 @@ async function start({
       s.close();
     }
   });
-
   const app = express();
   app.use(express.static(__dirname));
-
   const server = http.createServer(app);
   server.on('upgrade', (req, socket, head) => {
     presenceWss.handleUpgrade(req, socket, head, s => {
       presenceWss.emit('connection', s, req);
     });
   });
-
   return new Promise((accept, reject) => {
     server.listen(port, err => {
       if (err) return reject(err);

--- a/openvr/test/main.cpp
+++ b/openvr/test/main.cpp
@@ -7,6 +7,9 @@ using namespace v8;
 NAN_METHOD(initVr) {
   vr::HmdError hmdError;
   vr::VR_Init(&hmdError, vr::EVRApplicationType::VRApplication_Overlay);
+
+  // Return HmdError code https://github.com/ValveSoftware/openvr/wiki/HmdError
+  info.GetReturnValue().Set(hmdError);
 }
 
 std::unique_ptr<QrEngine> qrEngine;


### PR DESCRIPTION
This is part of https://github.com/webaverse/metachromium-bin/issues/12.

Previously, when the OpenVR initialisation failed, we didn't do anything with the error code.

This commit changes the behaviour of the qrvr C++ module to return the error code received from OpenVR, and the JS will exit the Node process with the returned error code, if non-0.

I've also added some details to the README that explain how to build the package locally, and the dependencies you need (after trying to get it to build myself, with help from @avaer)